### PR TITLE
5 convert 0

### DIFF
--- a/R/class-args.R
+++ b/R/class-args.R
@@ -248,7 +248,10 @@ arg_get_aliases <- function(self) {
 arg_get_name <- function(self) {
   aliases <- self$get_aliases()
 
-  if (self$action == "dots") {
+  if (self$get_action() == "dots") {
+    if (length(aliases) == 1L) {
+      return("...")
+    }
     ind <- seq_along(aliases)[-1L]
   } else {
     ind <- grep("^--?", aliases)

--- a/R/convert.R
+++ b/R/convert.R
@@ -41,6 +41,10 @@ value_convert <- function(x, to = default_convert) {
 }
 
 default_convert <- function(x) {
+  if (!length(x)) {
+    return(x)
+  }
+
   out <- utils::type.convert(x, as.is = TRUE)
 
   # only handles defaults

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -46,3 +46,9 @@ test_that("bad arguments don't create NULLs", {
   expect_identical(ca$nArgs, 0L)
   expect_identical(ca$argList, list())
 })
+
+test_that("$add_argument('...', default = character()) [#3]", {
+  obj <- command_args("foo")$add_argument("...")$parse()
+  exp <- list(... = "foo")
+  expect_identical(obj, exp)
+})

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -50,3 +50,7 @@ test_that("is_bool_like(), as_bool()", {
 
   expect_true(as_bool(TRUE))
 })
+
+test_that("default_convert(character()) [#5]", {
+  expect_identical(default_convert(character()), character())
+})


### PR DESCRIPTION
resolves #5

- #5 handle `dots` naming when no other alias is provided
- #5 don't convert zero length values (to logical)
- #5 add tests
