### PR TITLE
63 execute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scribe
 Title: Command Argument Parsing
-Version: 0.1.0.9005
+Version: 0.1.0.9006
 Authors@R: 
     person(
       given   = "Jordan Mark",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # scribe (development version)
 
+* `execute` is a new field for `scribeArg` where a function can be called [#63](https://github.com/jmbarbone/scribe/issues/63)
 * `stop` is a new field for `scribeArg` which controls how further arguments are parsed and allows for early stops [#60](https://github.com/jmbarbone/scribe/issues/60)
 * `options()` for `{scribe}` are now listed in `?scribe` documentation and set in `.onAttach()` [#57](https://github.com/jmbarbone/scribe/issues/57)
 * `--help` no longer fails when `scribeArg` has `length(info) > 1` [#59](https://github.com/jmbarbone/scribe/issues/59)

--- a/R/arg.R
+++ b/R/arg.R
@@ -21,7 +21,7 @@ new_arg <- function(
     info    = NULL,
     options = list(),
     stop    = c("none", "hard", "soft"),
-    execute = function(...) invisible()
+    execute = invisible
 ) {
   scribeArg$new(
     aliases = aliases,
@@ -45,10 +45,16 @@ scribe_help_arg <- function() {
     info = "prints this and quietly exits",
     options = list(no = FALSE),
     stop = "hard",
-    execute = function(arg, ca) {
-      if (isTRUE(arg$get_value())) {
+    execute = function(self, ca) {
+      if (isTRUE(self$get_value())) {
         ca$help()
-        exit()
+        return(exit())
+      }
+
+      if (isFALSE(self$get_value())) {
+        # remove 'help'
+        values <- ca$get_values()
+        ca$field("values", values[-match("help", names(values))])
       }
     }
   )
@@ -63,10 +69,16 @@ scribe_version_arg <- function() {
     info = "prints the version of {scribe} and quietly exits",
     options = list(no = FALSE),
     stop = "hard",
-    execute = function(arg, ca) {
-      if (isTRUE(arg$get_value())) {
+    execute = function(self, ca) {
+      if (isTRUE(self$get_value())) {
         ca$version()
-        exit()
+        return(exit())
+      }
+
+      if (isFALSE(self$get_value())) {
+        # remove 'version'
+        values <- ca$get_values()
+        ca$field("values", values[-match("version", names(values))])
       }
     }
   )
@@ -84,7 +96,7 @@ arg_initialize <- function( # nolint: cyclocomp_linter.
   info    = NA_character_,
   options = list(),
   stop    = c("none", "hard", "soft"),
-  execute = function(...) invisible()
+  execute = invisible
 ) {
   action  <- match.arg(action, arg_actions())
   info    <- info    %||% NA_character_
@@ -434,7 +446,7 @@ arg_parse_value <- function(self, ca) {
     )
 
     value <- value_convert(value, to = default %||% self$convert)
-    ca$field("stop", self$stop)
+    ca$field("stop", structure(self$stop, arg = self))
   }
 
   self$field("value", value)

--- a/R/arg.R
+++ b/R/arg.R
@@ -3,8 +3,8 @@
 #'
 #' Make a new [scribeArg] object
 #'
-#' @param aliases,action,convert,options,default,info,n,stop See `$initialize()`
-#'   in [scribeArg].
+#' @param aliases,action,convert,options,default,info,n,stop,execute See
+#'   `$initialize()` in [scribeArg].
 #' @examples
 #' new_arg()
 #' new_arg("values", action = "dots")
@@ -20,7 +20,8 @@ new_arg <- function(
     n       = NA_integer_,
     info    = NULL,
     options = list(),
-    stop    = c("none", "hard", "soft")
+    stop    = c("none", "hard", "soft"),
+    execute = function(...) invisible()
 ) {
   scribeArg$new(
     aliases = aliases,
@@ -30,7 +31,8 @@ new_arg <- function(
     n       = n,
     info    = info,
     options = options,
-    stop    = stop
+    stop    = stop,
+    execute = execute
   )
 }
 
@@ -42,7 +44,13 @@ scribe_help_arg <- function() {
     n = 0,
     info = "prints this and quietly exits",
     options = list(no = FALSE),
-    stop = "hard"
+    stop = "hard",
+    execute = function(arg, ca) {
+      if (isTRUE(arg$get_value())) {
+        ca$help()
+        exit()
+      }
+    }
   )
 }
 
@@ -54,7 +62,13 @@ scribe_version_arg <- function() {
     n = 0,
     info = "prints the version of {scribe} and quietly exits",
     options = list(no = FALSE),
-    stop = "hard"
+    stop = "hard",
+    execute = function(arg, ca) {
+      if (isTRUE(arg$get_value())) {
+        ca$version()
+        exit()
+      }
+    }
   )
 }
 
@@ -69,7 +83,8 @@ arg_initialize <- function( # nolint: cyclocomp_linter.
   n       = NA_integer_,
   info    = NA_character_,
   options = list(),
-  stop    = c("none", "hard", "soft")
+  stop    = c("none", "hard", "soft"),
+  execute = function(...) invisible()
 ) {
   action  <- match.arg(action, arg_actions())
   info    <- info    %||% NA_character_
@@ -211,6 +226,7 @@ arg_initialize <- function( # nolint: cyclocomp_linter.
   self$field("resolved", FALSE)
   self$field("value", NULL)
   self$field("stop", stop)
+  self$field("execute", execute)
   invisible(self)
 }
 
@@ -425,6 +441,7 @@ arg_parse_value <- function(self, ca) {
   self$field("resolved", TRUE)
   value
 }
+
 
 # helpers -----------------------------------------------------------------
 

--- a/R/class-args.R
+++ b/R/class-args.R
@@ -50,7 +50,10 @@
 #' @field value `[ANY]`\cr The resolve value
 #' @field stop `[character]`\cr `"none"`, `"hard"`, or `"soft"`
 #' @field execute `[function]`\cr (For advanced use).  A `function` to be
-#'   evaluated along with the arg.
+#'   evaluated along with the arg.  The function can have no parameters, a
+#'   single parameter for the [scribeArg] object, or accept the [scribeArg]
+#'   object as its first argument, and the [scribeCommandArgs] object as its
+#'   second.  Both objects will be passed by position
 #'
 #' @examples
 #' # new_arg() is recommended over direct use of scribeArg$new()
@@ -97,7 +100,7 @@ scribeArg$methods(
     info    = NA_character_,
     options = list(),
     stop    = c("none", "hard", "soft"),
-    execute = function(...) invisible()
+    execute = invisible
   ) {
     "
     Initialize the \\link{scribeArg} object
@@ -161,11 +164,6 @@ scribeArg$methods(
   get_value = function() {
     "Retrieve the resolved value"
     arg_get_value(.self)
-  },
-
-  do_execute = function(ca) {
-    "Perform the execute function"
-    arg_do_execute(.self, ca)
   },
 
   is_resolved = function() {

--- a/R/class-args.R
+++ b/R/class-args.R
@@ -49,6 +49,8 @@
 #' @field resolved `[logical]`\cr Has the object been resolved
 #' @field value `[ANY]`\cr The resolve value
 #' @field stop `[character]`\cr `"none"`, `"hard"`, or `"soft"`
+#' @field execute `[function]`\cr (For advanced use).  A `function` to be
+#'   evaluated along with the arg.
 #'
 #' @examples
 #' # new_arg() is recommended over direct use of scribeArg$new()
@@ -80,7 +82,8 @@ scribeArg <- methods::setRefClass( # nolint: object_name_linter.
     positional = "logical",
     resolved   = "logical",
     value      = "ANY",
-    stop       = "character"
+    stop       = "character",
+    execute    = "function"
   )
 )
 
@@ -93,7 +96,8 @@ scribeArg$methods(
     n       = NA_integer_,
     info    = NA_character_,
     options = list(),
-    stop    = c("none", "hard", "soft")
+    stop    = c("none", "hard", "soft"),
+    execute = function(...) invisible()
   ) {
     "
     Initialize the \\link{scribeArg} object
@@ -101,7 +105,7 @@ scribeArg$methods(
     See \\strong{fields} for parameter information.
     "
     arg_initialize(
-      .self,
+      self    = .self,
       aliases = aliases,
       action  = action,
       default = default,
@@ -109,7 +113,8 @@ scribeArg$methods(
       n       = n,
       info    = info,
       options = options,
-      stop    = stop
+      stop    = stop,
+      execute = execute
     )
   },
 
@@ -156,6 +161,11 @@ scribeArg$methods(
   get_value = function() {
     "Retrieve the resolved value"
     arg_get_value(.self)
+  },
+
+  do_execute = function(ca) {
+    "Perform the execute function"
+    arg_do_execute(.self, ca)
   },
 
   is_resolved = function() {

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -194,7 +194,7 @@ scribeCommandArgs$methods(
     default = NULL,
     n = NA_integer_,
     info = NULL,
-    execute = function(...) invisible()
+    execute = invisible
   ) {
     "Add a \\link{scribeArg} to \\code{args}
 

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -193,7 +193,8 @@ scribeCommandArgs$methods(
     convert = default_convert,
     default = NULL,
     n = NA_integer_,
-    info = NULL
+    info = NULL,
+    execute = function(...) invisible()
   ) {
     "Add a \\link{scribeArg} to \\code{args}
 

--- a/R/command-args.R
+++ b/R/command-args.R
@@ -193,11 +193,6 @@ ca_resolve <- function(self) {
   self$field("values", vector("list", length(arg_order)))
   names(self$values) <- arg_names[arg_order]
 
-  if (self$stop != "none") {
-    warning("$stop will be reset in $resolve()", call. = FALSE)
-    self$field("stop", "none")
-  }
-
   for (arg in args[arg_order]) {
     # TODO when `stop` is introduced, we'll have a `skipped` class
     self$set_values(arg$get_name(), arg_parse_value(arg, self))

--- a/R/scribe-package.R
+++ b/R/scribe-package.R
@@ -18,7 +18,8 @@ NULL
 
 op.scribe <- list( # nolint: object_name_linter.
   scribe.flag.no = TRUE,
-  scribe.interactive = NULL
+  scribe.interactive = NULL,
+  scribe.include = c("help", "version")
 )
 
 .onAttach <- function(libname, pkgname) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -95,7 +95,7 @@ ca$add_argument('-a', default = 1)
 ca$add_argument('-b', default = 2)
 args <- ca$parse()
 
-foo <- function(a, b) {
+foo <- function(a, b, ...) {
   a + b
 }
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ ca <- command_args(c("-a", "1", "-b", "1.0"))
 ca$add_argument("-a", convert = character())
 ca$add_argument("-b", convert = character())
 ca$parse()
+#> $help
+#> [1] FALSE
+#> 
+#> $version
+#> [1] FALSE
+#> 
 #> $a
 #> [1] "1"
 #> 
@@ -64,6 +70,12 @@ ca <- command_args(c("verbose", "1", "1.5", "1.9"))
 ca$add_argument("verbose", action = "flag")
 ca$add_argument("...", convert = integer())
 ca$parse()
+#> $help
+#> [1] FALSE
+#> 
+#> $version
+#> [1] FALSE
+#> 
 #> $verbose
 #> [1] TRUE
 #> 
@@ -75,6 +87,12 @@ ca <- command_args(c("verbose", "12-9-2022", "12-10-2022"))
 ca$add_argument("verbose", action = "flag")
 ca$add_argument("...", convert = function(i) as.Date(i, "%m-%d-%Y"))
 ca$parse()
+#> $help
+#> [1] FALSE
+#> 
+#> $version
+#> [1] FALSE
+#> 
 #> $verbose
 #> [1] TRUE
 #> 
@@ -101,7 +119,7 @@ ca$add_argument('-a', default = 1)
 ca$add_argument('-b', default = 2)
 args <- ca$parse()
 
-foo <- function(a, b) {
+foo <- function(a, b, ...) {
   a + b
 }
 

--- a/man/command_args.Rd
+++ b/man/command_args.Rd
@@ -6,7 +6,7 @@
 \usage{
 command_args(
   x = NULL,
-  include = c("help", "version", NA_character_),
+  include = getOption("scribe.include", c("help", "version", NA_character_)),
   string = NULL
 )
 }

--- a/man/new_arg.Rd
+++ b/man/new_arg.Rd
@@ -12,12 +12,13 @@ new_arg(
   n = NA_integer_,
   info = NULL,
   options = list(),
-  stop = c("none", "hard", "soft")
+  stop = c("none", "hard", "soft"),
+  execute = function(...) invisible()
 )
 }
 \arguments{
-\item{aliases, action, convert, options, default, info, n, stop}{See \verb{$initialize()}
-in \link{scribeArg}.}
+\item{aliases, action, convert, options, default, info, n, stop, execute}{See
+\verb{$initialize()} in \link{scribeArg}.}
 }
 \value{
 A \link{scribeArg} object

--- a/man/new_arg.Rd
+++ b/man/new_arg.Rd
@@ -13,7 +13,7 @@ new_arg(
   info = NULL,
   options = list(),
   stop = c("none", "hard", "soft"),
-  execute = function(...) invisible()
+  execute = invisible
 )
 }
 \arguments{

--- a/man/scribeArg-class.Rd
+++ b/man/scribeArg-class.Rd
@@ -45,14 +45,15 @@ printed}
 \item{\code{stop}}{\verb{[character]}\cr \code{"none"}, \code{"hard"}, or \code{"soft"}}
 
 \item{\code{execute}}{\verb{[function]}\cr (For advanced use).  A \code{function} to be
-evaluated along with the arg.}
+evaluated along with the arg.  The function can have no parameters, a
+single parameter for the \link{scribeArg} object, or accept the \link{scribeArg}
+object as its first argument, and the \link{scribeCommandArgs} object as its
+second.  Both objects will be passed by position}
 }}
 
 \section{Methods}{
 
 \describe{
-\item{\code{do_execute(ca)}}{Perform the execute function}
-
 \item{\code{get_action()}}{Retrieve action}
 
 \item{\code{get_aliases()}}{Retrieve aliases}
@@ -80,7 +81,7 @@ evaluated along with the arg.}
   info = NA_character_,
   options = list(),
   stop = c("none", "hard", "soft"),
-  execute = function(...) invisible()
+  execute = invisible
 )}}{    Initialize the \link{scribeArg} object
 
     See \strong{fields} for parameter information.

--- a/man/scribeArg-class.Rd
+++ b/man/scribeArg-class.Rd
@@ -43,11 +43,16 @@ printed}
 \item{\code{value}}{\verb{[ANY]}\cr The resolve value}
 
 \item{\code{stop}}{\verb{[character]}\cr \code{"none"}, \code{"hard"}, or \code{"soft"}}
+
+\item{\code{execute}}{\verb{[function]}\cr (For advanced use).  A \code{function} to be
+evaluated along with the arg.}
 }}
 
 \section{Methods}{
 
 \describe{
+\item{\code{do_execute(ca)}}{Perform the execute function}
+
 \item{\code{get_action()}}{Retrieve action}
 
 \item{\code{get_aliases()}}{Retrieve aliases}
@@ -74,7 +79,8 @@ printed}
   n = NA_integer_,
   info = NA_character_,
   options = list(),
-  stop = c("none", "hard", "soft")
+  stop = c("none", "hard", "soft"),
+  execute = function(...) invisible()
 )}}{    Initialize the \link{scribeArg} object
 
     See \strong{fields} for parameter information.

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -78,7 +78,7 @@ track parsing progress and is not meant to be accessed directly.}
   default = NULL,
   n = NA_integer_,
   info = NULL,
-  execute = function(...) invisible()
+  execute = invisible
 )}}{Add a \link{scribeArg} to \code{args}
 
     \describe{

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -77,7 +77,8 @@ track parsing progress and is not meant to be accessed directly.}
   convert = default_convert,
   default = NULL,
   n = NA_integer_,
-  info = NULL
+  info = NULL,
+  execute = function(...) invisible()
 )}}{Add a \link{scribeArg} to \code{args}
 
     \describe{

--- a/tests/testthat/test-arg-execute.R
+++ b/tests/testthat/test-arg-execute.R
@@ -22,3 +22,35 @@ test_that("execute works", {
   ca$set_input("2")
   expect_message(ca$parse(), "The value is: 4")
 })
+
+test_that("execute formals work", {
+  arg0 <- new_arg(
+    "a",
+    default = 1,
+    execute = function() stopifnot(TRUE)
+  )
+
+  arg1 <- new_arg(
+    "b",
+    default = 1,
+    execute = function(x) stopifnot(is_arg(x))
+  )
+
+  arg3 <- new_arg(
+    "c",
+    default = 1,
+    execute = function(x, y, z) {
+      stopifnot(
+        is_arg(x),
+        is_command_args(y),
+        missing(z)
+      )
+    }
+  )
+
+  ca <- command_args()
+  ca$add_argument(arg0)
+  ca$add_argument(arg1)
+  ca$add_argument(arg3)
+  expect_error(ca$parse(), NA)
+})

--- a/tests/testthat/test-arg-execute.R
+++ b/tests/testthat/test-arg-execute.R
@@ -1,0 +1,24 @@
+test_that("execute works", {
+  arg <- new_arg(
+    "foo",
+    default = 1L,
+    action = "list",
+    execute = function(arg, ...) {
+      message("The value is: ", arg$get_value()^2)
+    }
+  )
+
+  ca <- command_args(include = NA)
+  ca$add_argument(arg)
+
+  # sanity check
+  expect_failure(expect_identical(
+    ca$get_args()[[1]]$execute,
+    invisible
+  ))
+
+  expect_message(ca$parse(), "The value is: 1")
+
+  ca$set_input("2")
+  expect_message(ca$parse(), "The value is: 4")
+})

--- a/tests/testthat/test-arg-execute.R
+++ b/tests/testthat/test-arg-execute.R
@@ -8,7 +8,7 @@ test_that("execute works", {
     }
   )
 
-  ca <- command_args(include = NA)
+  ca <- command_args()
   ca$add_argument(arg)
 
   # sanity check

--- a/tests/testthat/test-class-args.R
+++ b/tests/testthat/test-class-args.R
@@ -93,7 +93,7 @@ test_that("new_arg(action = 'default')", {
 })
 
 test_that("action = 'flag' allows TRUE [#55]", {
-  ca <- command_args()
+  ca <- command_args(include = NA)
   expect_warning(
     ca$add_argument("--foo", action = "flag", default = TRUE),
     NA
@@ -120,7 +120,7 @@ test_that("pass arg as default [#54]", {
 })
 
 test_that("length(info) > 1 [#57]", {
-  ca <- command_args("--help")
+  ca <- command_args("--help", include = c("help", "version"))
   ca$add_argument("bad", info = c("one", "two"))
   expect_length(ca$get_args()[[3]]$get_help(), 2)
   expect_output(ca$parse())

--- a/tests/testthat/test-class-args.R
+++ b/tests/testthat/test-class-args.R
@@ -14,7 +14,7 @@ test_that("errors", {
   expect_error(new_arg(action = "flag", n = 1))
   expect_error(new_arg(c("foo", "--bar")))
 
-  ca <- command_args(string = "-a 2 -a 1", include = NA)
+  ca <- command_args(string = "-a 2 -a 1")
   ca$add_argument("-a")
   expect_warning(expect_warning(ca$parse()))
 })
@@ -93,7 +93,7 @@ test_that("new_arg(action = 'default')", {
 })
 
 test_that("action = 'flag' allows TRUE [#55]", {
-  ca <- command_args(include = NA)
+  ca <- command_args()
   expect_warning(
     ca$add_argument("--foo", action = "flag", default = TRUE),
     NA

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -2,7 +2,7 @@ withr::local_options(list(scribe.interactive = TRUE))
 
 test_that("command_args() works", {
   x <- c("-a", "1", "-b", "2")
-  ca <- command_args(x, include = NA)
+  ca <- command_args(x)
   ca$add_argument("-a", "--alpha")
   ca$add_argument("-b", "--beta")
 
@@ -20,7 +20,7 @@ test_that("command_args() works", {
 
 test_that("command_args() handles defaults", {
   foo <- function(x = character()) {
-    ca <- command_args(x, include = NA)
+    ca <- command_args(x)
     ca$add_argument("-a", "--alpha", default = 1L)
     ca$add_argument("-b", "--beta",  default = 1L)
     ca$parse()
@@ -41,7 +41,7 @@ test_that("command_args() handles defaults", {
 
 test_that("command_args() handles dots", {
   x <- c("-a", "1", "2", "3")
-  ca <- command_args(x, include = NA)
+  ca <- command_args(x)
   ca$add_argument("-a", "--alpha")
   ca$add_argument("...", "values")
   obj <- ca$parse()
@@ -76,33 +76,33 @@ test_that("resolving", {
 })
 
 test_that("$add_argument('...', default = character()) [#3]", {
-  obj <- command_args("foo", include = NA)$add_argument("...")$parse()
+  obj <- command_args("foo")$add_argument("...")$parse()
   exp <- list(... = "foo")
   expect_identical(obj, exp)
 })
 
 test_that("$add_argument('...', default = 'bar') [#11]", {
-  obj <- command_args("", include = NA)$add_argument("...", default = "bar")$parse()
+  obj <- command_args("")$add_argument("...", default = "bar")$parse()
   exp <- list(... = "bar")
   expect_identical(obj, exp)
 
-  obj <- command_args("", include = NA)$add_argument("...", default = 1:3)$parse()
+  obj <- command_args("")$add_argument("...", default = 1:3)$parse()
   exp <- list(... = 1:3)
   expect_identical(obj, exp)
 })
 
 test_that("$add_argument(action = 'flag') [#17]", {
-  ca <- command_args(include = NA)
+  ca <- command_args()
   ca$add_argument("-f", "--foo", action = "flag")
   obj <- ca$parse()
   exp <- list(foo = FALSE)
   expect_identical(obj, exp)
 
-  obj <- command_args("-f", include = NA)$add_argument("-f", "--foo", action = "flag")$parse()
+  obj <- command_args("-f")$add_argument("-f", "--foo", action = "flag")$parse()
   exp <- list(foo = TRUE)
   expect_identical(obj, exp)
 
-  obj <- command_args("--foo", include = NA)$add_argument("-f", "--foo", action = "flag")$parse() # nolint: line_length_linter.
+  obj <- command_args("--foo")$add_argument("-f", "--foo", action = "flag")$parse() # nolint: line_length_linter.
   exp <- list(foo = TRUE)
   expect_identical(obj, exp)
 
@@ -114,7 +114,7 @@ test_that("$add_argument(action = 'flag') [#17]", {
 
 test_that("$add_argument()", {
   # should be fine during creation
-  ca <- command_args(c("foo", "bar"), include = NA)
+  ca <- command_args(c("foo", "bar"))
   ca$add_argument("foo", action = "flag")
   ca$add_argument("bar", action = "flag")
 
@@ -137,7 +137,7 @@ test_that("$add_argument(named list)", {
 
 test_that("$add_argument() after initialization [#19]", {
   # should be okay after ca is created
-  ca <- command_args(include = NA)
+  ca <- command_args()
   obj <- ca$get_input()
   exp <- character()
   expect_identical(obj, exp)
@@ -166,7 +166,7 @@ test_that("$add_argument(arg) [#45]", {
 test_that("args are returned in original order [#25]", {
   ca <- command_args(
     c("-b", "one", "-c", "two", "-a", "three", "foo", "bar"),
-    include = NA
+
   )
   ca$add_argument("...")
   ca$add_argument("-a", default = "zero")
@@ -178,7 +178,7 @@ test_that("args are returned in original order [#25]", {
 })
 
 test_that("default values", {
-  ca <- command_args(c("1", "2.0", "3", "4.0"), include = NA)
+  ca <- command_args(c("1", "2.0", "3", "4.0"))
   ca$add_argument("one",   default = 0L)
   ca$add_argument("two",   default = 0)
   ca$add_argument("three", default = 0)
@@ -208,21 +208,21 @@ test_that("$get_args(included)", {
 })
 
 test_that("positional values [#22]", {
-  ca <- command_args(1:2, include = NA)
+  ca <- command_args(1:2)
   ca$add_argument("foo", default = 0)
   ca$add_argument("bar", default = 0)
   obj <- ca$parse()
   exp <- list(foo = 1, bar = 2)
   expect_identical(obj, exp)
 
-  ca <- command_args(c(1, "--bar", 2), include = NA)
+  ca <- command_args(c(1, "--bar", 2))
   ca$add_argument("foo", default = 0)
   ca$add_argument("--bar", default = 0)
   obj <- ca$parse()
   exp <- list(foo = 1, bar = 2)
   expect_identical(obj, exp)
 
-  ca <- command_args(c("--bar", 2, 1), include = NA)
+  ca <- command_args(c("--bar", 2, 1))
   ca$add_argument("foo", default = 0)
   ca$add_argument("--bar", default = 0)
   obj <- ca$parse()
@@ -231,13 +231,13 @@ test_that("positional values [#22]", {
 })
 
 test_that("n args [#20]", {
-  ca <- command_args(c("--values", "1", "2"), include = NA)
+  ca <- command_args(c("--values", "1", "2"))
   ca$add_argument("--values", n = 2)
   obj <- ca$parse()
   exp <- list(values = 1:2)
   expect_identical(obj, exp)
 
-  ca <- command_args(c("--values", 1:5), include = NA)
+  ca <- command_args(c("--values", 1:5))
   ca$add_argument("--values", n = 3)
   ca$add_argument("...")
   obj <- ca$parse()
@@ -266,7 +266,7 @@ test_that("--help has early stop", {
 })
 
 test_that("- parsed as _ [#33]", {
-  ca <- command_args("--foo-bar", include = NA)
+  ca <- command_args("--foo-bar")
   ca$add_argument("--foo-bar")
   obj <- ca$parse()
   exp <- list(foo_bar = NA)
@@ -274,7 +274,7 @@ test_that("- parsed as _ [#33]", {
 })
 
 test_that("--no-flag parses [#34]", {
-  ca <- command_args("--no-foo", include = NA)
+  ca <- command_args("--no-foo")
   ca$add_argument("-f", "--foo", action = "flag")
   obj <- ca$parse()
   exp <- list(foo = FALSE)
@@ -341,7 +341,7 @@ test_that("versions", {
 })
 
 test_that("positional defaults [#52]", {
-  ca <- command_args(include = NA)
+  ca <- command_args()
   ca$add_argument("pos", default = 1)
   obj <- ca$parse()
   exp <- list(pos = 1)
@@ -349,7 +349,7 @@ test_that("positional defaults [#52]", {
 })
 
 test_that("pass arg as default [#54]", {
-  ca <- command_args(include = NA)
+  ca <- command_args()
   arg <- new_arg("-a", action = "flag")
   ca$add_argument(arg)
   ca$add_argument("-b", default = arg)
@@ -375,14 +375,14 @@ test_that("pass arg as default [#54]", {
 })
 
 test_that("'stop' args [#60]", {
-  ca <- command_args(string = "-a -b", include = NA)
+  ca <- command_args(string = "-a -b")
   ca$add_argument("-a", action = "flag", stop = "hard")
   ca$add_argument("-b", action = "flag")
   obj <- ca$parse()
   exp <- list(a = TRUE)
   expect_identical(obj, exp)
 
-  ca <- command_args(string = "-a -b", include = NA)
+  ca <- command_args(string = "-a -b")
   ca$add_argument("-a", action = "flag", stop = "soft")
   ca$add_argument("-b", action = "flag")
   obj <- ca$parse()

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -2,7 +2,7 @@ withr::local_options(list(scribe.interactive = TRUE))
 
 test_that("command_args() works", {
   x <- c("-a", "1", "-b", "2")
-  ca <- command_args(x)
+  ca <- command_args(x, include = NA)
   ca$add_argument("-a", "--alpha")
   ca$add_argument("-b", "--beta")
 
@@ -20,7 +20,7 @@ test_that("command_args() works", {
 
 test_that("command_args() handles defaults", {
   foo <- function(x = character()) {
-    ca <- command_args(x)
+    ca <- command_args(x, include = NA)
     ca$add_argument("-a", "--alpha", default = 1L)
     ca$add_argument("-b", "--beta",  default = 1L)
     ca$parse()
@@ -41,7 +41,7 @@ test_that("command_args() handles defaults", {
 
 test_that("command_args() handles dots", {
   x <- c("-a", "1", "2", "3")
-  ca <- command_args(x)
+  ca <- command_args(x, include = NA)
   ca$add_argument("-a", "--alpha")
   ca$add_argument("...", "values")
   obj <- ca$parse()
@@ -76,33 +76,33 @@ test_that("resolving", {
 })
 
 test_that("$add_argument('...', default = character()) [#3]", {
-  obj <- command_args("foo")$add_argument("...")$parse()
+  obj <- command_args("foo", include = NA)$add_argument("...")$parse()
   exp <- list(... = "foo")
   expect_identical(obj, exp)
 })
 
 test_that("$add_argument('...', default = 'bar') [#11]", {
-  obj <- command_args("")$add_argument("...", default = "bar")$parse()
+  obj <- command_args("", include = NA)$add_argument("...", default = "bar")$parse()
   exp <- list(... = "bar")
   expect_identical(obj, exp)
 
-  obj <- command_args("")$add_argument("...", default = 1:3)$parse()
+  obj <- command_args("", include = NA)$add_argument("...", default = 1:3)$parse()
   exp <- list(... = 1:3)
   expect_identical(obj, exp)
 })
 
 test_that("$add_argument(action = 'flag') [#17]", {
-  ca <- command_args()
+  ca <- command_args(include = NA)
   ca$add_argument("-f", "--foo", action = "flag")
   obj <- ca$parse()
   exp <- list(foo = FALSE)
   expect_identical(obj, exp)
 
-  obj <- command_args("-f")$add_argument("-f", "--foo", action = "flag")$parse()
+  obj <- command_args("-f", include = NA)$add_argument("-f", "--foo", action = "flag")$parse()
   exp <- list(foo = TRUE)
   expect_identical(obj, exp)
 
-  obj <- command_args("--foo")$add_argument("-f", "--foo", action = "flag")$parse() # nolint: line_length_linter.
+  obj <- command_args("--foo", include = NA)$add_argument("-f", "--foo", action = "flag")$parse() # nolint: line_length_linter.
   exp <- list(foo = TRUE)
   expect_identical(obj, exp)
 
@@ -114,7 +114,7 @@ test_that("$add_argument(action = 'flag') [#17]", {
 
 test_that("$add_argument()", {
   # should be fine during creation
-  ca <- command_args(c("foo", "bar"))
+  ca <- command_args(c("foo", "bar"), include = NA)
   ca$add_argument("foo", action = "flag")
   ca$add_argument("bar", action = "flag")
 
@@ -137,7 +137,7 @@ test_that("$add_argument(named list)", {
 
 test_that("$add_argument() after initialization [#19]", {
   # should be okay after ca is created
-  ca <- command_args()
+  ca <- command_args(include = NA)
   obj <- ca$get_input()
   exp <- character()
   expect_identical(obj, exp)
@@ -164,7 +164,10 @@ test_that("$add_argument(arg) [#45]", {
 })
 
 test_that("args are returned in original order [#25]", {
-  ca <- command_args(c("-b", "one", "-c", "two", "-a", "three", "foo", "bar"))
+  ca <- command_args(
+    c("-b", "one", "-c", "two", "-a", "three", "foo", "bar"),
+    include = NA
+  )
   ca$add_argument("...")
   ca$add_argument("-a", default = "zero")
   ca$add_argument("-c", default = "zero")
@@ -175,7 +178,7 @@ test_that("args are returned in original order [#25]", {
 })
 
 test_that("default values", {
-  ca <- command_args(c("1", "2.0", "3", "4.0"))
+  ca <- command_args(c("1", "2.0", "3", "4.0"), include = NA)
   ca$add_argument("one",   default = 0L)
   ca$add_argument("two",   default = 0)
   ca$add_argument("three", default = 0)
@@ -205,21 +208,21 @@ test_that("$get_args(included)", {
 })
 
 test_that("positional values [#22]", {
-  ca <- command_args(1:2)
+  ca <- command_args(1:2, include = NA)
   ca$add_argument("foo", default = 0)
   ca$add_argument("bar", default = 0)
   obj <- ca$parse()
   exp <- list(foo = 1, bar = 2)
   expect_identical(obj, exp)
 
-  ca <- command_args(c(1, "--bar", 2))
+  ca <- command_args(c(1, "--bar", 2), include = NA)
   ca$add_argument("foo", default = 0)
   ca$add_argument("--bar", default = 0)
   obj <- ca$parse()
   exp <- list(foo = 1, bar = 2)
   expect_identical(obj, exp)
 
-  ca <- command_args(c("--bar", 2, 1))
+  ca <- command_args(c("--bar", 2, 1), include = NA)
   ca$add_argument("foo", default = 0)
   ca$add_argument("--bar", default = 0)
   obj <- ca$parse()
@@ -228,13 +231,13 @@ test_that("positional values [#22]", {
 })
 
 test_that("n args [#20]", {
-  ca <- command_args(c("--values", "1", "2"))
+  ca <- command_args(c("--values", "1", "2"), include = NA)
   ca$add_argument("--values", n = 2)
   obj <- ca$parse()
   exp <- list(values = 1:2)
   expect_identical(obj, exp)
 
-  ca <- command_args(c("--values", 1:5))
+  ca <- command_args(c("--values", 1:5), include = NA)
   ca$add_argument("--values", n = 3)
   ca$add_argument("...")
   obj <- ca$parse()
@@ -263,7 +266,7 @@ test_that("--help has early stop", {
 })
 
 test_that("- parsed as _ [#33]", {
-  ca <- command_args("--foo-bar")
+  ca <- command_args("--foo-bar", include = NA)
   ca$add_argument("--foo-bar")
   obj <- ca$parse()
   exp <- list(foo_bar = NA)
@@ -271,7 +274,7 @@ test_that("- parsed as _ [#33]", {
 })
 
 test_that("--no-flag parses [#34]", {
-  ca <- command_args("--no-foo")
+  ca <- command_args("--no-foo", include = NA)
   ca$add_argument("-f", "--foo", action = "flag")
   obj <- ca$parse()
   exp <- list(foo = FALSE)
@@ -327,7 +330,7 @@ test_that("examples snaps", {
 })
 
 test_that("versions", {
-  ca <- command_args(string = "--version")
+  ca <- command_args(string = "--version", include = "version")
   ca$add_argument("--foo")
   ca$add_argument("--bar")
   ca$add_description("This does things")
@@ -372,14 +375,14 @@ test_that("pass arg as default [#54]", {
 })
 
 test_that("'stop' args [#60]", {
-  ca <- command_args(string = "-a -b")
+  ca <- command_args(string = "-a -b", include = NA)
   ca$add_argument("-a", action = "flag", stop = "hard")
   ca$add_argument("-b", action = "flag")
   obj <- ca$parse()
   exp <- list(a = TRUE)
   expect_identical(obj, exp)
 
-  ca <- command_args(string = "-a -b")
+  ca <- command_args(string = "-a -b", include = NA)
   ca$add_argument("-a", action = "flag", stop = "soft")
   ca$add_argument("-b", action = "flag")
   obj <- ca$parse()

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -388,6 +388,10 @@ test_that("'stop' args [#60]", {
   obj <- ca$parse()
   exp <- list(a = TRUE, b = FALSE)
   expect_identical(obj, exp)
+
+  expect_identical(new_arg(stop = NA)$stop, "soft")
+  expect_identical(new_arg(stop = TRUE)$stop, "hard")
+  expect_identical(new_arg(stop = FALSE)$stop, "none")
 })
 
 test_that("snapshots", {


### PR DESCRIPTION
closes #63

- #63 clean up some tests
- #63 include new execute field
- #63 Create test-arg-execute.R
- #63 redoc
- correct do.call() usage
- #63 add missing stop tests
- #63 clean up execute
- #63 redoc
- #63 add more tests
- #63 news and version
- #63 undo some of those includes
- #63 remove unused check
