### PR TITLE
73 dashes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Depends:
     R (>= 3.6)
 Imports:
@@ -33,3 +33,4 @@ Config/testthat/edition: 3
 VignetteBuilder: knitr
 URL: https://jmbarbone.github.io/scribe/, https://github.com/jmbarbone/scribe
 BugReports: https://github.com/jmbarbone/scribe/issues
+Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scribe
 Title: Command Argument Parsing
-Version: 0.3.0.9000
+Version: 0.3.0.9001
 Authors@R: 
     person(
       given   = "Jordan Mark",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,14 @@
 # scribe (development version)
 
-- improves `ca$help()` printing
+- `---help`, `---version` _super_ arguments (`scribeSuperArg` objects) are now included with `scribeCommandArgs` 
+  - `command_args(super = included)` added
+  - internal `scribe_version_arg()` function (used with `command_args(include = "verison")` and called with `--version`) is now deprecated.  Using `---version` now returns the version of `{scribe}`
+  - internal `scribe_help_super()` now available via `---help` and returns information about `{scribe}`
+  `ca$get_args(super = TRUE)` returns `scribeSuerArg`s
+- `ca$help()` printing has been improved
 - corrects issue with `ca$parse()`
+- `ca$get_values(empty, super, included)` added to prevent filtering of specific argument types and values
+- internal linting improvements
 
 # scribe 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # scribe (development version)
 
-- `---help`, `---version` _super_ arguments (`scribeSuperArg` objects) are now included with `scribeCommandArgs` 
+- `---help`, `---version` _super_ arguments (`scribeSuperArg` objects) are now included with `scribeCommandArgs`.
+This are objects that (by default) can be called within any `scribeCommandArgs` and intended to hold additional information about the `{scribe}` package.
+These are not meant to be user accessible.
+  - `scribeCommandArgs` gain a new `field`, `supers`; a list of `scribeSuperArg` objects
   - `command_args(super = included)` added
   - internal `scribe_version_arg()` function (used with `command_args(include = "verison")` and called with `--version`) is now deprecated.  Using `---version` now returns the version of `{scribe}`
   - internal `scribe_help_super()` now available via `---help` and returns information about `{scribe}`
@@ -9,6 +12,9 @@
 - corrects issue with `ca$parse()`
 - `ca$get_values(empty, super, included)` added to prevent filtering of specific argument types and values
 - internal linting improvements
+- `new_arg()` now throws a more helpful error when _value doesn't convert to itself_
+- `arg$show()` now denotes if the argument is resolves by display an `"R"` before the value
+- `arg$show()` now prints values of class `"scribe_empty_value"` as `<empty>`
 
 # scribe 0.3.0
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -72,6 +72,7 @@ scribe_version_arg <- function() {
     stop = "hard",
     execute = function(self, ca) {
       if (isTRUE(self$get_value())) {
+        .Deprecated("For {scribe} package version, use ---version instead")
         ca$version()
         return(exit())
       }

--- a/R/arg.R
+++ b/R/arg.R
@@ -61,6 +61,7 @@ scribe_help_arg <- function() {
 }
 
 scribe_version_arg <- function() {
+  # TODO deprecate for ---version
   new_arg(
     aliases = "--version",
     action = "flag",

--- a/R/arg.R
+++ b/R/arg.R
@@ -182,7 +182,8 @@ arg_initialize <- function(
         "\nconverted:\n",
         utils::capture.output(utils::str(attempt)),
         "\n\n",
-        "to disable this check, set `convert = scribe_conert(\"none\")`",
+        "to disable this check, use",
+        " `new_arg(convert = scribe_convert(\"none\"))`",
         " or review the `convert` argument in `?scribe_arg`",
         call. = FALSE
       )

--- a/R/arg.R
+++ b/R/arg.R
@@ -50,12 +50,6 @@ scribe_help_arg <- function() {
         ca$help()
         return(exit())
       }
-
-      if (isFALSE(self$get_value())) {
-        # remove 'help'
-        values <- ca$get_values()
-        ca$field("values", values[-match("help", names(values))])
-      }
     }
   )
 }
@@ -75,12 +69,6 @@ scribe_version_arg <- function() {
         .Deprecated("For {scribe} package version, use ---version instead")
         ca$version()
         return(exit())
-      }
-
-      if (isFALSE(self$get_value())) {
-        # remove 'version'
-        values <- ca$get_values()
-        ca$field("values", values[-match("version", names(values))])
       }
     }
   )

--- a/R/arg.R
+++ b/R/arg.R
@@ -183,9 +183,20 @@ arg_initialize <- function( # nolint: cyclocomp_linter.
     }
   )
 
-  if (!is.null(default)) {
-    if (!identical(value_convert(default, to = convert), default)) {
-      stop("default value doesn't convert to itself", call. = FALSE)
+  if (!is.null(default) && !is.null(convert)) {
+    attempt <- value_convert(default, to = convert)
+    if (!identical(attempt, default)) {
+      stop(
+        "default value doesn't convert to itself:\n",
+        "default:\n",
+        utils::capture.output(utils::str(default)),
+        "\nconverted:\n",
+        utils::capture.output(utils::str(attempt)),
+        "\n\n",
+        "to disable this check, set `convert = scribe_conert(\"none\")`",
+        " or review the `convert` argument in `?scribe_arg`",
+        call. = FALSE
+      )
     }
   }
 
@@ -273,8 +284,9 @@ arg_show <- function(self) {
       "<null>"
     } else if (inherits(value, "scribe_empty_value")) {
       "<empty>"
-    } else if (!nzchar(value)) {
-      "<>"
+    # is this even needed?
+    # } else if (length(value) == 0 || !nzchar(value)) {
+    #   "<>"
     } else {
       paste(vapply(value, format, NA_character_), collapse = " ")
     }
@@ -282,11 +294,11 @@ arg_show <- function(self) {
   aliases <- self$get_aliases()
   aliases <- to_string(aliases)
   print_line(sprintf(
-      "Argument [%s] %s: %s",
-      aliases,
-      if (self$is_resolved()) "R " else "",
-      value
-    ))
+    "Argument [%s] %s: %s",
+    aliases,
+    if (self$is_resolved()) "R " else "",
+    value
+  ))
   invisible(self)
 }
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -88,17 +88,18 @@ scribe_version_arg <- function() {
 
 # wrappers ----------------------------------------------------------------
 
-arg_initialize <- function( # nolint: cyclocomp_linter.
-  self,
-  aliases = "",
-  action  = arg_actions(),
-  default = NULL,
-  convert = scribe_convert(),
-  n       = NA_integer_,
-  info    = NA_character_,
-  options = list(),
-  stop    = c("none", "hard", "soft"),
-  execute = invisible
+# nolint next: cyclocomp_linter.
+arg_initialize <- function(
+    self,
+    aliases = "",
+    action  = arg_actions(),
+    default = NULL,
+    convert = scribe_convert(),
+    n       = NA_integer_,
+    info    = NA_character_,
+    options = list(),
+    stop    = c("none", "hard", "soft"),
+    execute = invisible
 ) {
   action  <- match.arg(action, arg_actions())
   info    <- info    %||% NA_character_
@@ -284,9 +285,6 @@ arg_show <- function(self) {
       "<null>"
     } else if (inherits(value, "scribe_empty_value")) {
       "<empty>"
-    # is this even needed?
-    # } else if (length(value) == 0 || !nzchar(value)) {
-    #   "<>"
     } else {
       paste(vapply(value, format, NA_character_), collapse = " ")
     }
@@ -413,7 +411,8 @@ arg_is_resolved <- function(self) {
 
 # internal ----------------------------------------------------------------
 
-arg_parse_value <- function(self, ca) { # nolint: cyclocomp_linter.
+# nolint next: cyclocomp_linter.
+arg_parse_value <- function(self, ca) {
   default <-
     if (is_arg(self$default)) {
       self$default$get_value()

--- a/R/class-args.R
+++ b/R/class-args.R
@@ -171,3 +171,24 @@ scribeArg$methods(
     arg_is_resolved(.self)
   }
 )
+
+scribeSuperArg <- methods::setRefClass(
+  "scribeSuperArg",
+  contains = "scribeArg",
+  methods = list(
+    initialize = function(
+      aliases = "",
+      ...
+    ) {
+      if (!all(startsWith(aliases, "---"))) {
+        stop("super args aliases must start with ---")
+      }
+
+      arg_initialize(
+        self    = .self,
+        aliases = aliases,
+        ...
+      )
+    }
+  )
+)

--- a/R/class-args.R
+++ b/R/class-args.R
@@ -72,7 +72,8 @@
 #' new_arg("...", info = "list of values") # defaults when alias is "..."
 #' @family scribe
 #' @export
-scribeArg <- methods::setRefClass( # nolint: object_name_linter.
+# nolint next: object_name_linter.
+scribeArg <- methods::setRefClass(
   "scribeArg",
   fields       = list(
     aliases    = "character",
@@ -172,23 +173,22 @@ scribeArg$methods(
   }
 )
 
-scribeSuperArg <- methods::setRefClass(
-  "scribeSuperArg",
-  contains = "scribeArg",
-  methods = list(
-    initialize = function(
-      aliases = "",
-      ...
-    ) {
-      if (!all(startsWith(aliases, "---"))) {
-        stop("super args aliases must start with ---")
-      }
+# nolint next: object_name_linter.
+scribeSuperArg <- methods::setRefClass("scribeSuperArg", contains = "scribeArg")
 
-      arg_initialize(
-        self    = .self,
-        aliases = aliases,
-        ...
-      )
+scribeSuperArg$methods(
+  initialize = function(
+    aliases = "",
+    ...
+  ) {
+    if (!all(startsWith(aliases, "---"))) {
+      stop("super args aliases must start with ---")
     }
-  )
+
+    arg_initialize(
+      self    = .self,
+      aliases = aliases,
+      ...
+    )
+  }
 )

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -39,7 +39,7 @@
 #'   See also [command_args()]
 #' @field values `[list]`\cr A named `list` of values.  Empty on initialization
 #'   and populated during argument resolving.
-#' @field args `[list]`\cr a List of [scribeArg]s
+#' @field args `[list]`\cr A List of [scribeArg]s
 #' @field description `[character]`\cr Additional help information
 #' @field included `[character]`\cr Default [scribeArg]s to include
 #' @field examples `[character]`\cr Examples to print with help
@@ -49,6 +49,7 @@
 #' @field working `[character]`\cr A copy of `input`.  Note: this is used to
 #'   track parsing progress and is not meant to be accessed directly.
 #' @field stop `[character]`\cr Determines parsing
+#' @field supers `[list]`\cr A list of `scribeSuperArgs`s
 #'
 #' @examples
 #' # command_args() is recommended over direct use of scribeCommandArgs$new()
@@ -97,8 +98,7 @@ scribeCommandArgs <- methods::setRefClass( # nolint: object_name_linter.
     resolved = "logical",
     working = "character",
     stop = "character",
-    super = "logical",
-    supers = "character"
+    supers = "list"
   )
 )
 
@@ -107,7 +107,7 @@ scribeCommandArgs$methods(
   initialize = function(
     input = "",
     include = c("help", "version", NA_character_),
-    super = TRUE
+    supers = include
   ) {
     "Initialize the \\link{scribeCommandArgs} object.  The wrapper
     \\code{\\link[=command_args]{command_args()}} is recommended rather than
@@ -118,8 +118,11 @@ scribeCommandArgs$methods(
         to parse}
       \\item{\\code{include}}{A character vector denoting which default
         \\link{scribeArg}s to include in \\code{args}}
+      \\item{\\code{supers}}{A character vector denoting which default
+        \\code{scribeSuperArg}s to include in \\code{supers} (i.e., arguments
+        called with `---` prefixes)
     }"
-    ca_initialize(.self, input = input, include = include, super = super)
+    ca_initialize(.self, input = input, include = include, supers = supers)
   },
 
   show = function(...) {
@@ -179,14 +182,15 @@ scribeCommandArgs$methods(
     ca_set_values(.self, i = i, value = value)
   },
 
-  get_args = function(included = TRUE) {
+  get_args = function(included = TRUE, super = FALSE) {
     "Retrieve \\code{args}
 
     \\describe{
       \\item{\\code{included}}{If \\code{TRUE} also returns included default
         \\link{scribeArg}s defined in \\code{$initialize()}}
+      \\item{\\code{super}}{If \\code{TRUE} also returns super args
     }"
-    ca_get_args(.self, included = included)
+    ca_get_args(.self, included = included, super = super)
   },
 
   add_argument = function(

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -96,7 +96,8 @@ scribeCommandArgs <- methods::setRefClass( # nolint: object_name_linter.
     comments = "character",
     resolved = "logical",
     working = "character",
-    stop = "character"
+    stop = "character",
+    super = "logical"
   )
 )
 
@@ -104,7 +105,8 @@ scribeCommandArgs$methods(
   # creates the object
   initialize = function(
     input = "",
-    include = c("help", "version", NA_character_)
+    include = c("help", "version", NA_character_),
+    super = TRUE
   ) {
     "Initialize the \\link{scribeCommandArgs} object.  The wrapper
     \\code{\\link[=command_args]{command_args()}} is recommended rather than
@@ -116,7 +118,7 @@ scribeCommandArgs$methods(
       \\item{\\code{include}}{A character vector denoting which default
         \\link{scribeArg}s to include in \\code{args}}
     }"
-    ca_initialize(.self, input = input, include = include)
+    ca_initialize(.self, input = input, include = include, super = super)
   },
 
   show = function(...) {

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -167,9 +167,13 @@ scribeCommandArgs$methods(
     ca_set_input(.self, value = value)
   },
 
-  get_values = function() {
-    "Retrieve \\code{values}"
-    ca_get_values(.self)
+  get_values = function(all = FALSE) {
+    "Retrieve \\code{values}
+    \\describe{
+      \\item{\\code{{all}}}{If \\code{TRUE} returns all values, including empty
+      ones}
+    }"
+    ca_get_values(.self, all = all)
   },
 
   set_values = function(i = TRUE, value) {

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -120,7 +120,7 @@ scribeCommandArgs$methods(
         \\link{scribeArg}s to include in \\code{args}}
       \\item{\\code{supers}}{A character vector denoting which default
         \\code{scribeSuperArg}s to include in \\code{supers} (i.e., arguments
-        called with `---` prefixes)
+        called with `---` prefixes)}
     }"
     ca_initialize(.self, input = input, include = include, supers = supers)
   },
@@ -161,9 +161,8 @@ scribeCommandArgs$methods(
     "Set \\code{input}.  Note: when called, \\code{resolved} is (re)set to
      \\code{FALSE} and values need to be parsed again.
 
-    \\describe{
-      \\item{\\code{value}}{Value to set}
-    }"
+    \\describe{\\item{\\code{value}}{Value to set}}
+    "
     ca_set_input(.self, value = value)
   },
 
@@ -192,7 +191,7 @@ scribeCommandArgs$methods(
     \\describe{
       \\item{\\code{included}}{If \\code{TRUE} also returns included default
         \\link{scribeArg}s defined in \\code{$initialize()}}
-      \\item{\\code{super}}{If \\code{TRUE} also returns super args
+      \\item{\\code{super}}{If \\code{TRUE} also returns super args}
     }"
     ca_get_args(.self, included = included, super = super)
   },

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -85,7 +85,8 @@
 #' do.call(my_function, args)
 #' @family scribe
 #' @export
-scribeCommandArgs <- methods::setRefClass( # nolint: object_name_linter.
+# nolint next: object_name_linter.
+scribeCommandArgs <- methods::setRefClass(
   "scribeCommandArgs",
   fields = list(
     input = "character",

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -97,7 +97,8 @@ scribeCommandArgs <- methods::setRefClass( # nolint: object_name_linter.
     resolved = "logical",
     working = "character",
     stop = "character",
-    super = "logical"
+    super = "logical",
+    supers = "character"
   )
 )
 

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -167,14 +167,19 @@ scribeCommandArgs$methods(
     ca_set_input(.self, value = value)
   },
 
-  get_values = function(all = FALSE, super = FALSE) {
+  get_values = function(
+    empty = FALSE,
+    super = FALSE,
+    included = FALSE
+  ) {
     "Retrieve \\code{values}
     \\describe{
-      \\item{\\code{{all}}}{If \\code{TRUE} returns all values, including empty
-      ones}
+      \\item{\\code{{empty}}}{If \\code{TRUE} returns empty values, too}
       \\item{\\code{super}}{If \\code{TRUE} also returns values from super args}
+      \\item{\\code{included}}{If \\code{TRUE} also returns included default
+        \\link{scribeArg}s defined in \\code{$initialize()}}
     }"
-    ca_get_values(.self, all = all, super = super)
+    ca_get_values(.self, empty = empty, super = super, included = included)
   },
 
   set_values = function(i = TRUE, value) {

--- a/R/class-command-args.R
+++ b/R/class-command-args.R
@@ -167,13 +167,14 @@ scribeCommandArgs$methods(
     ca_set_input(.self, value = value)
   },
 
-  get_values = function(all = FALSE) {
+  get_values = function(all = FALSE, super = FALSE) {
     "Retrieve \\code{values}
     \\describe{
       \\item{\\code{{all}}}{If \\code{TRUE} returns all values, including empty
       ones}
+      \\item{\\code{super}}{If \\code{TRUE} also returns values from super args}
     }"
-    ca_get_values(.self, all = all)
+    ca_get_values(.self, all = all, super = super)
   },
 
   set_values = function(i = TRUE, value) {

--- a/R/command-args.R
+++ b/R/command-args.R
@@ -9,8 +9,10 @@
 #'   Otherwise the value of `x` is converted to a `character`.  If `string` is
 #'   not `NULL`, [scan()] will be used to split the value into a `character`
 #'   vector.
-#' @param include Special default arguments to included.  See `$initialize()`
-#'   in [scribeCommandArgs] for more details.
+#' @param include Special default arguments to included.  See `$initialize()` in
+#'   [scribeCommandArgs] for more details.
+#' @param super When `TRUE` the [scribeCommandArgs] object will be initialized
+#'   with standard _super_ arguments (e.g., `---help`, `---version`)
 #' @examples
 #' command_args()
 #' command_args(c("-a", 1, "-b", 2))
@@ -21,7 +23,8 @@
 command_args <- function(
     x = NULL,
     include = getOption("scribe.include", c("help", "version", NA_character_)),
-    string = NULL
+    string = NULL,
+    super = TRUE
 ) {
   if (is.null(string)) {
     if (is.null(x)) {
@@ -37,7 +40,7 @@ command_args <- function(
     x <- scan(text = string, what = "character", quiet = TRUE)
   }
 
-  scribeCommandArgs(input = x, include = include)
+  scribeCommandArgs(input = x, include = include, super = super)
 }
 
 # wrappers ----------------------------------------------------------------
@@ -45,7 +48,8 @@ command_args <- function(
 ca_initialize <- function(
     self,
     input = NULL,
-    include = c("help", "version", NA_character_)
+    include = c("help", "version", NA_character_),
+    super = TRUE
 ) {
   # default values
   self$initFields(
@@ -75,6 +79,7 @@ ca_initialize <- function(
     self$add_argument(scribe_version_arg())
   }
 
+  self$field("super", super)
   self$field("input", as.character(input) %||% character())
   self$field("working", self$input)
   self$field("included", include)

--- a/R/command-args.R
+++ b/R/command-args.R
@@ -210,6 +210,27 @@ ca_resolve <- function(self) {
   self$field("values", vector("list", length(arg_order)))
   names(self$values) <- arg_names[arg_order]
 
+  if (self$super) {
+    # NOTE if a third is added, this should probably be a function
+    for (i in seq_along(ca_get_working(self))) {
+      switch(
+        ca_get_working(self)[i],
+        "---help" = {
+          scribe_help_super()
+          self$field("stop", "hard")
+          self$field("supers", c(self$supers, "help"))
+          self$field("working", ca_get_working(self)[-i])
+        },
+        "---version" = {
+          scribe_version_super()
+          self$field("stop", "hard")
+          self$field("supers", c(self$supers, "version"))
+          self$field("working", ca_get_working(self)[-i])
+        }
+      )
+    }
+  }
+
   for (arg in args[arg_order]) {
     self$set_values(arg$get_name(), arg_parse_value(arg, self))
   }
@@ -229,6 +250,14 @@ ca_resolve <- function(self) {
 
 ca_parse <- function(self) {
   self$resolve()
+
+  for (arg in self$supers) {
+    switch(
+      arg,
+      "help" = scribe_help_super()$execute(),
+      "version" = scribe_version_super()$execute()
+    )
+  }
 
   for (arg in self$get_args()) {
     ca_do_execute(self, arg)

--- a/R/command-args.R
+++ b/R/command-args.R
@@ -244,11 +244,10 @@ ca_parse <- function(self) {
   }
 
   # clean up names
-  values <- self$get_values()
-  values <- values[!startsWith(names(values), "_")]
-  regmatches(names(values), regexpr("^-+", names(values))) <- ""
-  regmatches(names(values), gregexpr("-", names(values))) <- "_"
-  values
+  res <- self$get_values(super = FALSE)
+  regmatches(names(res), regexpr("^-+", names(res))) <- ""
+  regmatches(names(res), gregexpr("-", names(res))) <- "_"
+  res
 }
 
 ca_get_input <- function(self) {
@@ -262,12 +261,22 @@ ca_set_input <- function(self, value) {
   invisible(self)
 }
 
-ca_get_values <- function(self, all = FALSE) {
-  if (all) {
-    return(self$values)
+ca_get_values <- function(self, all = FALSE, super = FALSE) {
+  values <- self$values
+
+  if (is.null(values) || length(values) == 0) {
+    return(list())
   }
 
-  Filter(function(x) !inherits(x, "scribe_empty_value"), self$values)
+  if (!super) {
+    values <- values[!startsWith(names(values), "_")]
+  }
+
+  if (all) {
+    return(values)
+  }
+
+  Filter(function(x) !inherits(x, "scribe_empty_value"), values)
 }
 
 ca_set_values <- function(self, i = NULL, value) {

--- a/R/command-args.R
+++ b/R/command-args.R
@@ -271,7 +271,7 @@ ca_get_values <- function(
 ) {
   values <- self$values
 
-  if (!included && !is.null(names(values))) {
+  if (!included) {
     values <- values[setdiff(names(values), self$included)]
   }
 

--- a/R/command-args.R
+++ b/R/command-args.R
@@ -97,7 +97,7 @@ ca_initialize <- function(
   invisible(self)
 }
 
-ca_show <- function(self, ...) {
+ca_show <- function(self, all_values = FALSE, ...) {
   print_line("Initial call: ", to_string(self$get_input()))
 
   if (!self$resolved) {
@@ -248,11 +248,7 @@ ca_parse <- function(self) {
   values <- values[!startsWith(names(values), "_")]
   regmatches(names(values), regexpr("^-+", names(values))) <- ""
   regmatches(names(values), gregexpr("-", names(values))) <- "_"
-  if (length(values)) {
-    values
-  } else {
-    list()
-  }
+  values
 }
 
 ca_get_input <- function(self) {
@@ -266,7 +262,11 @@ ca_set_input <- function(self, value) {
   invisible(self)
 }
 
-ca_get_values <- function(self) {
+ca_get_values <- function(self, all = FALSE) {
+  if (all) {
+    return(self$values)
+  }
+
   Filter(function(x) !inherits(x, "scribe_empty_value"), self$values)
 }
 

--- a/R/scribe-package.R
+++ b/R/scribe-package.R
@@ -15,8 +15,8 @@
 NULL
 
 # nolint end: line_length_linter.
-
-op.scribe <- list( # nolint: object_name_linter.
+# nolint next: object_name_linter.
+op.scribe <- list(
   scribe.flag.no = TRUE,
   scribe.interactive = NULL,
   scribe.include = c("help", "version")

--- a/R/super-arg.R
+++ b/R/super-arg.R
@@ -1,0 +1,49 @@
+scribe_super_help_arg <- function() {
+  new_arg(
+    aliases = "---help",
+    action = "flag",
+    default = FALSE,
+    n = 0,
+    info = "prints help information for {scribe} and quietly exits",
+    options = list(no = FALSE),
+    stop = "hard",
+    execute = function(self, ca) {
+      # TODO include more information
+      if (isTRUE(self$get_value())) {
+        cat(
+          "{scribe} v ", scribe_version,
+          "For more information, see https://jmbarbone.github.io/scribe/"
+        )
+        return(exit())
+      }
+    }
+  )
+}
+
+scribe_super_version_arg <- function() {
+  new_arg(
+    aliases = "---version",
+    action = "flag",
+    default = FALSE,
+    n = 0,
+    info = "prints the version of {scribe} and quietly exits",
+    options = list(no = FALSE),
+    stop = "hard",
+    execute = function(self, ca) {
+      if (isTRUE(self$get_value())) {
+        ca$version()
+        return(exit())
+      }
+
+      if (isFALSE(self$get_value())) {
+        # remove 'version'
+        values <- ca$get_values()
+        ca$field("values", values[-match("version", names(values))])
+      }
+    }
+  )
+}
+
+scribe_version <- function() {
+  format(utils::packageVersion("scribe"))
+}

--- a/R/super-arg.R
+++ b/R/super-arg.R
@@ -1,3 +1,6 @@
+# default super helpers.  though these may be the only super helpers.  the
+# object is not exported so these should only be used internally.
+
 scribe_help_super <- function() {
   new_arg(
     aliases = "---help",
@@ -9,7 +12,7 @@ scribe_help_super <- function() {
     stop = "hard",
     execute = function() {
       cat(
-        "{scribe} v ", format(scribe_version()), "\n",
+        "{scribe} v", format(scribe_version()), "\n",
         "For more information, see https://jmbarbone.github.io/scribe/",
         sep =
       )

--- a/R/super-arg.R
+++ b/R/super-arg.R
@@ -1,4 +1,4 @@
-scribe_super_help_arg <- function() {
+scribe_help_super <- function() {
   new_arg(
     aliases = "---help",
     action = "flag",
@@ -7,20 +7,18 @@ scribe_super_help_arg <- function() {
     info = "prints help information for {scribe} and quietly exits",
     options = list(no = FALSE),
     stop = "hard",
-    execute = function(self, ca) {
-      # TODO include more information
-      if (isTRUE(self$get_value())) {
-        cat(
-          "{scribe} v ", scribe_version,
-          "For more information, see https://jmbarbone.github.io/scribe/"
-        )
-        return(exit())
-      }
+    execute = function() {
+      cat(
+        "{scribe} v ", format(scribe_version()), "\n",
+        "For more information, see https://jmbarbone.github.io/scribe/",
+        sep =
+      )
+      exit()
     }
   )
 }
 
-scribe_super_version_arg <- function() {
+scribe_version_super <- function() {
   new_arg(
     aliases = "---version",
     action = "flag",
@@ -30,20 +28,14 @@ scribe_super_version_arg <- function() {
     options = list(no = FALSE),
     stop = "hard",
     execute = function(self, ca) {
-      if (isTRUE(self$get_value())) {
-        ca$version()
-        return(exit())
-      }
-
-      if (isFALSE(self$get_value())) {
-        # remove 'version'
-        values <- ca$get_values()
-        ca$field("values", values[-match("version", names(values))])
-      }
+      cat(format(scribe_version()), "\n", sep = "")
+      exit()
     }
   )
 }
 
 scribe_version <- function() {
-  format(utils::packageVersion("scribe"))
+  package_version(
+    asNamespace("scribe")[[".__NAMESPACE__."]][["spec"]][["version"]]
+  )
 }

--- a/R/super-arg.R
+++ b/R/super-arg.R
@@ -11,16 +11,14 @@ scribe_help_super <- function() {
     options = list(no = FALSE),
     stop = "hard",
     execute = function(self, ca) {
-      if (!self$get_value()) {
-        return()
+      if (isTRUE(self$get_value())) {
+        cat(
+          "{scribe} v", format(scribe_version()), "\n",
+          "For more information, see https://jmbarbone.github.io/scribe/\n",
+          sep = ""
+        )
+        exit()
       }
-
-      cat(
-        "{scribe} v", format(scribe_version()), "\n",
-        "For more information, see https://jmbarbone.github.io/scribe/\n",
-        sep = ""
-      )
-      exit()
     }
   )
 }
@@ -35,12 +33,10 @@ scribe_version_super <- function() {
     options = list(no = FALSE),
     stop = "hard",
     execute = function(self, ca) {
-      if (!isTRUE(self$get_value())) {
-        return()
+      if (isTRUE(self$get_value())) {
+        cat(format(scribe_version()), "\n", sep = "")
+        exit()
       }
-
-      cat(format(scribe_version()), "\n", sep = "")
-      exit()
     }
   )
 }

--- a/R/super-arg.R
+++ b/R/super-arg.R
@@ -2,7 +2,7 @@
 # object is not exported so these should only be used internally.
 
 scribe_help_super <- function() {
-  new_arg(
+  scribeSuperArg$new(
     aliases = "---help",
     action = "flag",
     default = FALSE,
@@ -10,11 +10,15 @@ scribe_help_super <- function() {
     info = "prints help information for {scribe} and quietly exits",
     options = list(no = FALSE),
     stop = "hard",
-    execute = function() {
+    execute = function(self, ca) {
+      if (!self$get_value()) {
+        return()
+      }
+
       cat(
         "{scribe} v", format(scribe_version()), "\n",
         "For more information, see https://jmbarbone.github.io/scribe/",
-        sep =
+        sep = ""
       )
       exit()
     }
@@ -22,7 +26,7 @@ scribe_help_super <- function() {
 }
 
 scribe_version_super <- function() {
-  new_arg(
+  scribeSuperArg$new(
     aliases = "---version",
     action = "flag",
     default = FALSE,
@@ -31,6 +35,10 @@ scribe_version_super <- function() {
     options = list(no = FALSE),
     stop = "hard",
     execute = function(self, ca) {
+      if (!isTRUE(self$get_value())) {
+        return()
+      }
+
       cat(format(scribe_version()), "\n", sep = "")
       exit()
     }

--- a/R/super-arg.R
+++ b/R/super-arg.R
@@ -17,7 +17,7 @@ scribe_help_super <- function() {
 
       cat(
         "{scribe} v", format(scribe_version()), "\n",
-        "For more information, see https://jmbarbone.github.io/scribe/",
+        "For more information, see https://jmbarbone.github.io/scribe/\n",
         sep = ""
       )
       exit()

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,10 +54,10 @@ exit <- function(force = !getOption("scribe.interactive", interactive())) {
   invisible()
 }
 
-# nolint start: object_name_linter.
+# nolint next: object_name_linter.
 wapply <- function(x, FUN, ...) {
+  # nolint next: object_name_linter.
   FUN <- match.fun(FUN)
-  # nolint end: object_name_linter.
   fun <- function(x, ...) isTRUE(FUN(x, ...))
   which(do.call(vapply, list(X = x, FUN = fun, FUN.VALUE = NA)))
 }

--- a/man/command_args.Rd
+++ b/man/command_args.Rd
@@ -7,7 +7,8 @@
 command_args(
   x = NULL,
   include = getOption("scribe.include", c("help", "version", NA_character_)),
-  string = NULL
+  string = NULL,
+  super = TRUE
 )
 }
 \arguments{
@@ -18,8 +19,11 @@ Otherwise the value of \code{x} is converted to a \code{character}.  If \code{st
 not \code{NULL}, \code{\link[=scan]{scan()}} will be used to split the value into a \code{character}
 vector.}
 
-\item{include}{Special default arguments to included.  See \verb{$initialize()}
-in \link{scribeCommandArgs} for more details.}
+\item{include}{Special default arguments to included.  See \verb{$initialize()} in
+\link{scribeCommandArgs} for more details.}
+
+\item{super}{When \code{TRUE} the \link{scribeCommandArgs} object will be initialized
+with standard \emph{super} arguments (e.g., \code{---help}, \code{---version})}
 }
 \value{
 A \link{scribeCommandArgs} object

--- a/man/command_args.Rd
+++ b/man/command_args.Rd
@@ -8,7 +8,7 @@ command_args(
   x = NULL,
   include = getOption("scribe.include", c("help", "version", NA_character_)),
   string = NULL,
-  super = TRUE
+  super = include
 )
 }
 \arguments{

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -48,7 +48,7 @@ See also \code{\link[=command_args]{command_args()}}}
 \item{\code{values}}{\verb{[list]}\cr A named \code{list} of values.  Empty on initialization
 and populated during argument resolving.}
 
-\item{\code{args}}{\verb{[list]}\cr a List of \link{scribeArg}s}
+\item{\code{args}}{\verb{[list]}\cr A List of \link{scribeArg}s}
 
 \item{\code{description}}{\verb{[character]}\cr Additional help information}
 
@@ -65,6 +65,8 @@ and populated during argument resolving.}
 track parsing progress and is not meant to be accessed directly.}
 
 \item{\code{stop}}{\verb{[character]}\cr Determines parsing}
+
+\item{\code{supers}}{\verb{[list]}\cr A list of \code{scribeSuperArgs}s}
 }}
 
 \section{Methods}{
@@ -104,11 +106,12 @@ track parsing progress and is not meant to be accessed directly.}
       \item{\code{prefix}}{An optional prefix for the example}
     }}
 
-\item{\code{get_args(included = TRUE)}}{Retrieve \code{args}
+\item{\code{get_args(included = TRUE, super = FALSE)}}{Retrieve \code{args}
 
     \describe{
       \item{\code{included}}{If \code{TRUE} also returns included default
         \link{scribeArg}s defined in \code{$initialize()}}
+      \item{\code{super}}{If \code{TRUE} also returns super args
     }}
 
 \item{\code{get_description()}}{Retrieve \code{description}}
@@ -124,7 +127,7 @@ track parsing progress and is not meant to be accessed directly.}
 \item{\code{initialize(
   input = "",
   include = c("help", "version", NA_character_),
-  super = TRUE
+  supers = include
 )}}{Initialize the \link{scribeCommandArgs} object.  The wrapper
     \code{\link[=command_args]{command_args()}} is recommended rather than
     calling this method directly.
@@ -134,6 +137,9 @@ track parsing progress and is not meant to be accessed directly.}
         to parse}
       \item{\code{include}}{A character vector denoting which default
         \link{scribeArg}s to include in \code{args}}
+      \item{\code{supers}}{A character vector denoting which default
+        \code{scribeSuperArg}s to include in \code{supers} (i.e., arguments
+        called with `---` prefixes)
     }}
 
 \item{\code{parse()}}{Return a named \code{list} of parsed values of from each \link{scribeArg}

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -111,7 +111,7 @@ track parsing progress and is not meant to be accessed directly.}
     \describe{
       \item{\code{included}}{If \code{TRUE} also returns included default
         \link{scribeArg}s defined in \code{$initialize()}}
-      \item{\code{super}}{If \code{TRUE} also returns super args
+      \item{\code{super}}{If \code{TRUE} also returns super args}
     }}
 
 \item{\code{get_description()}}{Retrieve \code{description}}
@@ -120,7 +120,11 @@ track parsing progress and is not meant to be accessed directly.}
 
 \item{\code{get_input()}}{Retrieve \code{input}}
 
-\item{\code{get_values()}}{Retrieve \code{values}}
+\item{\code{get_values(all = FALSE)}}{Retrieve \code{values}
+\describe{
+  \item{\code{{all}}}{If \code{TRUE} returns all values, including empty
+  ones}
+}}
 
 \item{\code{help()}}{Print the help information}
 
@@ -139,7 +143,7 @@ track parsing progress and is not meant to be accessed directly.}
         \link{scribeArg}s to include in \code{args}}
       \item{\code{supers}}{A character vector denoting which default
         \code{scribeSuperArg}s to include in \code{supers} (i.e., arguments
-        called with `---` prefixes)
+        called with `---` prefixes)}
     }}
 
 \item{\code{parse()}}{Return a named \code{list} of parsed values of from each \link{scribeArg}
@@ -166,9 +170,8 @@ is called prior to $parse()}
 \item{\code{set_input(value)}}{Set \code{input}.  Note: when called, \code{resolved} is (re)set to
      \code{FALSE} and values need to be parsed again.
 
-    \describe{
-      \item{\code{value}}{Value to set}
-    }}
+    \describe{\item{\code{value}}{Value to set}}
+    }
 
 \item{\code{set_values(i = TRUE, value)}}{Set \code{values}
 

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -121,7 +121,11 @@ track parsing progress and is not meant to be accessed directly.}
 
 \item{\code{help()}}{Print the help information}
 
-\item{\code{initialize(input = "", include = c("help", "version", NA_character_))}}{Initialize the \link{scribeCommandArgs} object.  The wrapper
+\item{\code{initialize(
+  input = "",
+  include = c("help", "version", NA_character_),
+  super = TRUE
+)}}{Initialize the \link{scribeCommandArgs} object.  The wrapper
     \code{\link[=command_args]{command_args()}} is recommended rather than
     calling this method directly.
 

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -120,11 +120,12 @@ track parsing progress and is not meant to be accessed directly.}
 
 \item{\code{get_input()}}{Retrieve \code{input}}
 
-\item{\code{get_values(all = FALSE, super = FALSE)}}{Retrieve \code{values}
+\item{\code{get_values(empty = FALSE, super = FALSE, included = FALSE)}}{Retrieve \code{values}
 \describe{
-  \item{\code{{all}}}{If \code{TRUE} returns all values, including empty
-  ones}
+  \item{\code{{empty}}}{If \code{TRUE} returns empty values, too}
   \item{\code{super}}{If \code{TRUE} also returns values from super args}
+  \item{\code{included}}{If \code{TRUE} also returns included default
+    \link{scribeArg}s defined in \code{$initialize()}}
 }}
 
 \item{\code{help()}}{Print the help information}

--- a/man/scribeCommandArgs-class.Rd
+++ b/man/scribeCommandArgs-class.Rd
@@ -120,10 +120,11 @@ track parsing progress and is not meant to be accessed directly.}
 
 \item{\code{get_input()}}{Retrieve \code{input}}
 
-\item{\code{get_values(all = FALSE)}}{Retrieve \code{values}
+\item{\code{get_values(all = FALSE, super = FALSE)}}{Retrieve \code{values}
 \describe{
   \item{\code{{all}}}{If \code{TRUE} returns all values, including empty
   ones}
+  \item{\code{super}}{If \code{TRUE} also returns values from super args}
 }}
 
 \item{\code{help()}}{Print the help information}

--- a/scribe.Rproj
+++ b/scribe.Rproj
@@ -1,8 +1,8 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
-AlwaysSaveHistory: Default
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes

--- a/tests/testthat/_snaps/class-args.md
+++ b/tests/testthat/_snaps/class-args.md
@@ -12,3 +12,17 @@
     Output
       [...] help text
 
+---
+
+    Code
+      arg$show()
+    Output
+      Argument [foo] : 0
+
+---
+
+    Code
+      arg$show()
+    Output
+      Argument [foo] R : 1
+

--- a/tests/testthat/_snaps/class-command-args.md
+++ b/tests/testthat/_snaps/class-command-args.md
@@ -194,7 +194,7 @@
     Code
       command_args("---help")$parse()
     Output
-      {scribe} v0.3.0.9000
+      {scribe} v0.3.0.9001
       For more information, see https://jmbarbone.github.io/scribe/
       named list()
 
@@ -203,6 +203,6 @@
     Code
       command_args("---version")$parse()
     Output
-      0.3.0.9000
+      0.3.0.9001
       named list()
 

--- a/tests/testthat/_snaps/class-command-args.md
+++ b/tests/testthat/_snaps/class-command-args.md
@@ -168,3 +168,41 @@
         --help    prints this and quietly exits                   
         --version prints the version of {scribe} and quietly exits
 
+# snapshots - empty values
+
+    Code
+      ca$get_args()
+    Output
+      [[1]]
+      Argument [--help] R : FALSE
+      
+      [[2]]
+      Argument [--version] R : FALSE
+      
+      [[3]]
+      Argument [--foo] R : <null>
+      
+      [[4]]
+      Argument [--bar] R : zero
+      
+      [[5]]
+      Argument [--fizz] R : <empty>
+      
+
+# snapshots - super args
+
+    Code
+      command_args("---help")$parse()
+    Output
+      {scribe} v0.3.0.9000
+      For more information, see https://jmbarbone.github.io/scribe/
+      named list()
+
+---
+
+    Code
+      command_args("---version")$parse()
+    Output
+      0.3.0.9000
+      named list()
+

--- a/tests/testthat/test-class-args.R
+++ b/tests/testthat/test-class-args.R
@@ -171,4 +171,13 @@ test_that("snapshots", {
   expect_output(arg$help())
   expect_snapshot(arg$show())
   expect_snapshot(arg$help())
+
+  ca <- command_args(1)
+  arg <- new_arg("foo", default = 0)
+  ca$add_argument(arg)
+  expect_snapshot(arg$show())
+
+  # now resolve the argument so we have a different print
+  ca$resolve()
+  expect_snapshot(arg$show())
 })

--- a/tests/testthat/test-class-args.R
+++ b/tests/testthat/test-class-args.R
@@ -56,10 +56,7 @@ test_that("help() [#16]", {
   exp <- c("...", "help text")
   expect_identical(obj, exp)
 
-  obj <- new_arg(
-    c("...", "dots"),
-    info = "more help here"
-  )$get_help()
+  obj <- new_arg(c("...", "dots"), info = "more help here")$get_help()
   exp <- c("...", "dots: more help here")
   expect_identical(obj, exp)
 

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -332,7 +332,10 @@ test_that("versions", {
   ca$add_argument("--foo")
   ca$add_argument("--bar")
   ca$add_description("This does things")
-  expect_output((obj <- ca$parse()))
+  expect_warning(
+    expect_output((obj <- ca$parse())),
+    class = "deprecatedWarning"
+  )
   exp <- list(version = TRUE)
   expect_identical(obj, exp)
   expect_output(ca$version())

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -161,6 +161,46 @@ test_that("$add_argument(arg) [#45]", {
   expect_identical(obj, exp)
 })
 
+test_that("$get_values() [#73]", {
+  # #73 includes super args
+  ca <- command_args(1L)
+  ca$add_argument("foo")
+  ca$add_argument("bar")
+  obj <- ca$get_values()
+  exp <- list()
+  expect_identical(obj, exp)
+
+  ca$resolve()
+
+  obj <- ca$get_values()
+  exp <- list(foo = 1L, bar = NULL)
+  expect_identical(obj, exp)
+  obj <- ca$get_values()
+
+  obj <- ca$get_values(included = TRUE)
+  exp <- list(help = FALSE, version = FALSE, foo = 1L, bar = NULL)
+  expect_identical(obj, exp)
+
+  obj <- ca$get_values(super = TRUE)
+  exp <- list(`_help` = FALSE, `_version` = FALSE, foo = 1L, bar = NULL)
+  expect_identical(obj, exp)
+})
+
+test_that("$get_values(empty)", {
+  ca <- command_args("--stop")
+  ca$add_argument("foo")
+  ca$add_argument("--stop", stop = TRUE)
+  ca$resolve()
+
+  obj <- ca$get_values()
+  exp <- list(stop = NA)
+  expect_identical(obj, exp)
+
+  obj <- ca$get_values(empty = TRUE)
+  exp <- list(foo = scribe_empty_value(), stop = NA)
+  expect_identical(obj, exp)
+})
+
 test_that("args are returned in original order [#25]", {
   ca <- command_args(
     c("-b", "one", "-c", "two", "-a", "three", "foo", "bar"),

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -413,3 +413,18 @@ test_that("snapshots", {
   expect_snapshot(ca$show())
   expect_snapshot(ca$help())
 })
+
+test_that("snapshots - empty values", {
+  ca <- command_args(string = "--bar zero")
+  ca$add_argument("--foo", stop = "hard")
+  ca$add_argument("--bar", action = "list", default = character(), stop = "hard")
+  ca$add_argument("--fizz", action = "list", default = character())
+  ca$resolve()
+  ca$get_args()
+  expect_snapshot(ca$get_args())
+})
+
+test_that("snapshots - super args", {
+  expect_snapshot(command_args("---help")$parse())
+  expect_snapshot(command_args("---version")$parse())
+})

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -416,8 +416,8 @@ test_that("snapshots", {
 
 test_that("snapshots - empty values", {
   ca <- command_args(string = "--bar zero")
-  ca$add_argument("--foo", stop = "hard")
-  ca$add_argument("--bar", action = "list", default = character(), stop = "hard")
+  ca$add_argument("--foo", stop = TRUE)
+  ca$add_argument("--bar", action = "list", default = character(), stop = TRUE)
   ca$add_argument("--fizz", action = "list", default = character())
   ca$resolve()
   ca$get_args()

--- a/tests/testthat/test-class-command-args.R
+++ b/tests/testthat/test-class-command-args.R
@@ -298,7 +298,7 @@ test_that("--help has early stop", {
   ca <- command_args("--help")
   ca$add_argument("-v")
   ca$add_argument("-f")
-  exp <- list(help = TRUE)
+  exp <- structure(list(), names = character())
   expect_output(obj <- try(ca$parse()))
   expect_identical(obj, exp)
 })
@@ -376,7 +376,7 @@ test_that("versions", {
     expect_output((obj <- ca$parse())),
     class = "deprecatedWarning"
   )
-  exp <- list(version = TRUE)
+  exp <- structure(list(), names = character())
   expect_identical(obj, exp)
   expect_output(ca$version())
 })

--- a/tests/testthat/test-class-super-args.R
+++ b/tests/testthat/test-class-super-args.R
@@ -1,0 +1,14 @@
+withr::local_options(list(scribe.interactive = TRUE))
+
+test_that("---version, ---help", {
+  expect_output(command_args("---version")$parse())
+  expect_output(command_args("---help")$parse())
+})
+
+test_that("errors", {
+  expect_error(
+    scribeSuperArg$new("foo"),
+    regexp = "super args aliases must start with ---",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
resolves #73

- Create super-arg.R (#73)
- create scribeSuperArg object (#73)
- begin implementing super args (#73)
- add checks for super (#73)
- redoc (#73)
- deprecate --version (or the default one) (#73)
- add deprecated check (#73)
- formatting (#73)
- Update super-arg.R (#73)
- include setting supers for command args (#73)
- account for three dashes better (#73)
- formatting (#73)
- redoc (#73)
- add super tests (#73)
- update snaps (#73)
- Update test-class-args.R (#73)
- add option for all values (#73)
- clean up docs (#73)
- formatting, mostly (#73)
- get values (#73)
- improve get values and redoc (#73)
- Create test-class-super-args.R (#73)
- add more tests for new values (#73)
- remove attempts to remove 'help' and 'version' from values (#73)
- update tests with new get_values() (#73)
- clean up (#73)
- Update NEWS.md (#73)
- clean up help text (#73)
- only check for included when pulling values (#73)
- bump version (#73)
- update NEWS (#73)
